### PR TITLE
print the actual state of an object created via `parallelGetOptions()` rather than returning the global options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - `parallelLibrary()`: Respect custom levels when exporting packages (#67) 
 
+- Bugfix: Printing the state of an object holding the current parallelMap options (queried via `parallelGetOptions()`) did not return the object state but instead the global state of the options (#41, @mb706).
+
 # parallelMap 1.4
 
 - Load balancing for multicore, socket and mpi can now be controlled via the flag

--- a/R/parallelShowOptions.R
+++ b/R/parallelShowOptions.R
@@ -23,8 +23,8 @@ parallelGetOptions = function() {
 print.ParallelMapOptions = function(x, ...) {
 
   mycat = function(opt) {
-    opt1val = opts$settings[[opt]]
-    opt2val = opts$defaults[[opt]]
+    opt1val = x$settings[[opt]]
+    opt2val = x$defaults[[opt]]
     if (opt == "bj.resources") {
       opt1val = ifelse(length(opt1val) == 0L, "(defaults from BatchJobs config)",
         convertToShortString(opt1val))
@@ -41,7 +41,6 @@ print.ParallelMapOptions = function(x, ...) {
       catf("%-20s: %-10s\n                      (%s)", opt, opt1val, opt2val)
     }
   }
-  opts = parallelGetOptions()
   catf("%-20s: %-10s (%s)", "parallelMap options", "value", "default")
   catf("")
   mycat("mode")

--- a/tests/testthat/test_parallelGetOptions.R
+++ b/tests/testthat/test_parallelGetOptions.R
@@ -10,3 +10,15 @@ test_that("get / print options", {
     print(parallelGetOptions())
   )
 })
+
+# issue https://github.com/mlr-org/parallelMap/issues/41
+test_that("parallelGetOptions() prints the state of the object", {
+  parallelStartSocket(2)
+  y = parallelGetOptions()
+  parallelStop()
+
+  expect_match(
+    capture.output(print(y))[3],
+    "mode                : socket     \\(not set\\)"
+  )
+})


### PR DESCRIPTION
fixes #41 

Just added a unit test to the fixes by @mb706  